### PR TITLE
Add Subscription - Update Product action

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The **AutomateWoo Subscriptions Add-on** makes it possible to modify some of the
 The **AutomateWoo Subscriptions Add-on** adds 4 new actions:
 
 * **Update Schedule**: to change a subscription's billing period or interval.
+* **Update Product**: to change a product line item's quantity, name or price.
 * **Add Shipping**: to add a chosen shipping method as a new line item, with a custom cost and name, on subscriptions.
 * **Update Shipping**: to update a shipping method's name or amount on a subscription.
 * **Remove Shipping**: to remove a chosen shipping method from a subscription.
@@ -37,7 +38,7 @@ With these actions, it's possible to change a subscription's:
 * billing schedule, for example, to switch a subscription from being billed annually to monthly
 * shipping costs at different stages of the the subscription lifecycle, for example, to only charge shipping annually, despite renewing monthly
 
-Combined with the existing built-in Subscriptions actions in AutomateWoo that can add, update or remove product line items, these actions make it possible to offer customers dynamic subscription lifecycles, like:
+Combined with the existing built-in Subscriptions actions in AutomateWoo that can add or remove product and coupon line items, these actions make it possible to offer customers dynamic subscription lifecycles, like:
 
 * magazines which ship monthly but are billed annually or quarterly
 * pre-paid subscriptions, where a customer can choose to pay for a given period up-front

--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -100,6 +100,11 @@ final class AutomateWoo_Subscriptions {
 
 		$actions = wcs_array_insert_after( 'subscription_send_invoice', $actions, 'subscription_update_schedule', 'AutomateWoo_Subscriptions\Action_Subscription_Update_Schedule' );
 
+		// Allow AutomateWoo core to override our Update Product action in future
+		if ( ! class_exists( 'AutomateWoo\Action_Subscription_Update_Product' ) ) {
+			$actions = wcs_array_insert_after( 'subscription_add_product', $actions, 'subscription_update_product', 'AutomateWoo_Subscriptions\Action_Subscription_Update_Product' );
+		}
+
 		$actions = array_merge( $actions, [
 			'subscription_add_shipping'    => 'AutomateWoo_Subscriptions\Action_Subscription_Add_Shipping',
 			'subscription_update_shipping' => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Shipping',

--- a/includes/actions/update-product.php
+++ b/includes/actions/update-product.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace AutomateWoo_Subscriptions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Action to update a chosen product line item to a subscription with a chosen quantity.
+ *
+ * @class Action_Subscription_Update_Product
+ * @since 4.4
+ */
+class Action_Subscription_Update_Product extends \AutomateWoo\Action_Subscription_Edit_Product_Abstract {
+
+
+	/**
+	 * Variable products should not be updateed as a line item to subscriptions, only variations.
+	 *
+	 * @var bool
+	 */
+	protected $allow_variable_products = false;
+
+
+	/**
+	 * Flag to define whether the instance of this action requires a name text input field.
+	 *
+	 * @var bool
+	 */
+	protected $load_name_field = true;
+
+
+	/**
+	 * Flag to define whether the instance of this action requires a price input field to
+	 * be displayed on the action's admin UI.
+	 *
+	 * @var bool
+	 */
+	protected $load_cost_field = true;
+
+
+	/**
+	 * Do not require the quantity input field.
+	 *
+	 * @var bool
+	 */
+	protected $require_quantity_field = false;
+
+	/**
+	 * Add product fields to the action's admin UI, but make sure quantity field is not required.
+	 *
+	 * The Action_Subscription_Edit_Item_Abstract::$require_quantity_field prop was introduced in
+	 * AutomateWoo 4.5, so we need to do it manually if we've got a version before that. Similarly,
+	 * the quantity fields description was not customised with AW < 4.5, because the method for that
+	 * Action_Subscription_Edit_Item_Abstract::get_quantity_field_description() wasn't being used.
+	 */
+	function load_fields() {
+		parent::load_fields();
+		if ( false === \PP_Dependencies::is_automatewoo_active( '4.5' ) ) {
+			$this->fields['quantity']->set_required( false );
+			$this->fields['quantity']->set_description( $this->get_quantity_field_description() );
+		}
+	}
+
+	/**
+	 * Explain to store admin what this action does via a unique title and description.
+	 */
+	function load_admin_details() {
+		parent::load_admin_details();
+		$this->title       = __( 'Update Product', 'automatewoo-subscriptions' );
+		$this->description = __( 'Update an existing product line item on a subscription. Only the data set on the action will be updated. This action can be used for bulk editing subscriptions, like changing price or product name', 'automatewoo-subscriptions' );
+	}
+
+
+	/**
+	 * Update a given product as a line item to a given subscription.
+	 *
+	 * @param \WC_Product      $product Product to update to the subscription.
+	 * @param \WC_Subscription $subscription Instance of subscription to update the product to.
+	 */
+	protected function edit_subscription( $product, $subscription ) {
+
+		$item = null;
+
+		foreach ( $subscription->get_items() as $subscription_item ) {
+			// Both of these ID getters will return the variation_id if the product is a variation.
+			if ( $product->get_id() === $subscription_item->get_product_id() ) {
+				$item = $subscription_item;
+				break;
+			}
+		}
+
+		// No item for that product on this subscription
+		if ( empty( $item ) ) {
+			return;
+		}
+
+		$update_product_args = array();
+
+		if ( $this->get_option( 'line_item_name' ) ) {
+			$update_product_args['name'] = $this->get_option( 'line_item_name', true );
+		}
+
+		if ( $this->get_option( 'line_item_cost' ) || $this->get_option( 'quantity' ) ) {
+
+			$update_product_args['quantity'] = ( $this->get_option( 'quantity' ) ) ? $this->get_option( 'quantity' ) : $item->get_quantity();
+
+			$update_product_args['subtotal'] = $update_product_args['total'] = wc_get_price_excluding_tax( $product, array(
+				'price' => $this->get_option( 'line_item_cost' ),
+				'qty'   => $update_product_args['quantity'],
+			) );
+		}
+
+		if ( ! empty( $update_product_args ) ) {
+			$item->set_props( $update_product_args );
+			$item->save();
+		}
+
+		// Now we need to refresh the subscription to make sure it has the up-to-date line item then recalculate its totals so taxes etc. are updated
+		$subscription = wcs_get_subscription( $subscription->get_id() );
+		$subscription->calculate_totals();
+	}
+
+
+	/**
+	 * Get the description to display on the quantity field for this action
+	 */
+	protected function get_quantity_field_description() {
+		return __( 'Optionally set a new quantity for the product. Defaults to the current quantity set on the subscription.', 'automatewoo-subscriptions' );
+	}
+
+	/**
+	 * Get a message to update to the subscription to record the product being updateed by this action.
+	 *
+	 * Helpful for tracing the history of this action by viewing the subscription's notes.
+	 *
+	 * @param \WC_Product $product Product being updateed to the subscription. Required so its name can be updateed to the order note.
+	 * @return string
+	 */
+	protected function get_note( $product ) {
+		return sprintf( __( '%1$s workflow run: updated %2$s on subscription. (Product ID: %3$d; Workflow ID: %4$d)', 'automatewoo-subscriptions' ), $this->workflow->get_title(), $product->get_name(), $product->get_id(), $this->workflow->get_id() );
+	}
+}


### PR DESCRIPTION
Add new _Subscription - Update Product_ action. This action will be handy for bulk editing products on a subscription to do things like bulk edit product name or [price](http://ideas.woocommerce.com/forums/133476-woocommerce/suggestions/17552416-bulk-update-subscription-price-when-subscription-p).

This supersedes the PR proposing the action for AutomateWoo core: https://github.com/Prospress/automatewoo/pull/127

For now, I think it's better to include this action in this add-on rather than AutomateWoo core. That will allow us to iterate more quickly on the action and reduce any potential negative impacts of bugs or unexpected usage, as this extension will have a smaller user base than AutomateWoo.

## AutomateWoo Version Compatibility

This will work with AutomateWoo 4.4.0 and newer (the minimum version required by this extension).

The original PR added code to the `Action_Subscription_Edit_Item_Abstract` class to make it possible for the the quantity field to be optional. This isn't required, as we can achieve the same thing within the `Action_Subscription_Update_Product` class itself by accessing the field via `$this->fields['quantity']`. This PR adds the `Action_Subscription_Update_Product::load_fields()` method to do that.

However, it's also assumed this will only be temporarily required and after AW 4.5.0, it will no longer be required. This assumed that https://github.com/Prospress/automatewoo/pull/149 will be merged by the time AW 4.5.0 is released.

### Empty Strings for the Number Field

AutomateWoo prior to https://github.com/Prospress/automatewoo/commit/9e2025f414a382376aa637788a5fe8d57ac6600f  (currently unreleased, but slated for 4.4.3) does not allow an empty string to be used for the `Number` field. It will Cast it to be `0`.

This means the quantity input field isn't optional in practice.

I didn't feel this issue was sufficient to update the required version of AutomateWoo to be 4.4.3, because by the time a lot of folks are actually using this plugin, I suspect 4.4.3 will be a distant memory; however, if we get feedback on issues with that, I will update the dependency.

## Future Proofing

To allow for this action to be moved to AutomateWoo core in future, the action is also only being added when `! class_exists( 'AutomateWoo\Action_Subscription_Update_Product' )`. As this is being added right from the start, there will be no version juggling or anything like that required, and no updates to this plugin. AutomateWoo just needs to make sure the action name is `Action_Subscription_Update_Product`.