### PR TITLE
Change prefix of PP_Dependencies

### DIFF
--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -36,20 +36,20 @@
  * @since		1.0
  */
 
-require_once( 'includes/class-pp-dependencies.php' );
+require_once( 'includes/class-aws-dependencies.php' );
 
-if ( false === PP_Dependencies::is_woocommerce_active( '3.0' ) ) {
-	PP_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'WooCommerce', '3.0' );
+if ( false === AWS_Dependencies::is_woocommerce_active( '3.0' ) ) {
+	AWS_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'WooCommerce', '3.0' );
 	return;
 }
 
-if ( false === PP_Dependencies::is_subscriptions_active( '2.4' ) ) {
-	PP_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'WooCommerce Subscriptions', '2.4' );
+if ( false === AWS_Dependencies::is_subscriptions_active( '2.4' ) ) {
+	AWS_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'WooCommerce Subscriptions', '2.4' );
 	return;
 }
 
-if ( false === PP_Dependencies::is_automatewoo_active( '4.4' ) ) {
-	PP_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'AutomateWoo', '4.4' );
+if ( false === AWS_Dependencies::is_automatewoo_active( '4.4' ) ) {
+	AWS_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'AutomateWoo', '4.4' );
 	return;
 }
 

--- a/includes/class-aws-dependencies.php
+++ b/includes/class-aws-dependencies.php
@@ -1,13 +1,16 @@
 <?php
 
-if ( ! class_exists( 'PP_Dependencies' ) ) :
+if ( ! class_exists( 'AWS_Dependencies' ) ) :
 
 /**
- * Prospress Dependency Checker
+ * AutomateWoo Subscriptions Dependency Checker
  *
- * Checks if WooCommerce and Subscriptions are enabled
+ * Methods to check if AutomateWoo, WooCommerce and Subscriptions are enabled.
+ *
+ * Based on Prospress Dependency Checker, but uses different prefix to avoid conflicts
+ * with version of it installed, as it does not include is_automatewoo_active().
  */
-class PP_Dependencies {
+class AWS_Dependencies {
 
 	protected static $admin_notices = array();
 
@@ -200,6 +203,6 @@ class PP_Dependencies {
 
 }
 
-PP_Dependencies::init();
+AWS_Dependencies::init();
 
 endif;


### PR DESCRIPTION
To avoid conflicts with other plugins that may have an out-of-date version of the class, which does not include `is_automatewoo_active()`.

We could version `PP_Dependencies` or take numerous other approaches to address this, but this is the simplest for now.

Fixes #8