### PR TITLE
Process variables in action price fields

### DIFF
--- a/includes/abstracts/actions/edit-shipping.php
+++ b/includes/abstracts/actions/edit-shipping.php
@@ -51,7 +51,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 	protected function get_object_for_edit() {
 		return [
 			'shipping_method_id' => $this->get_option( 'shipping_method_id' ),
-			'line_item_name'     => $this->get_option( 'line_item_name' ),
+			'line_item_name'     => $this->get_option( 'line_item_name', true ),
 			'line_item_cost'     => $this->get_option( 'line_item_cost', true ),
 		];
 	}

--- a/includes/abstracts/actions/edit-shipping.php
+++ b/includes/abstracts/actions/edit-shipping.php
@@ -94,7 +94,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 	/**
 	 * Get the codes of all non-AutomateWoo shippings.
 	 *
-	 * @return WC_Shipping_Method[]
+	 * @return \WC_Shipping_Method[]
 	 */
 	protected function get_shipping_methods() {
 		return WC()->shipping() ? WC()->shipping->load_shipping_methods() : [];

--- a/includes/abstracts/actions/edit-shipping.php
+++ b/includes/abstracts/actions/edit-shipping.php
@@ -52,7 +52,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 		return [
 			'shipping_method_id' => $this->get_option( 'shipping_method_id' ),
 			'line_item_name'     => $this->get_option( 'line_item_name' ),
-			'line_item_cost'     => $this->get_option( 'line_item_cost' ),
+			'line_item_cost'     => $this->get_option( 'line_item_cost', true ),
 		];
 	}
 

--- a/includes/actions/update-product.php
+++ b/includes/actions/update-product.php
@@ -107,7 +107,7 @@ class Action_Subscription_Update_Product extends \AutomateWoo\Action_Subscriptio
 			$update_product_args['quantity'] = ( $this->get_option( 'quantity' ) ) ? $this->get_option( 'quantity' ) : $item->get_quantity();
 
 			$update_product_args['subtotal'] = $update_product_args['total'] = wc_get_price_excluding_tax( $product, array(
-				'price' => $this->get_option( 'line_item_cost' ),
+				'price' => $this->get_option( 'line_item_cost', true ),
 				'qty'   => $update_product_args['quantity'],
 			) );
 		}

--- a/includes/actions/update-schedule.php
+++ b/includes/actions/update-schedule.php
@@ -52,7 +52,7 @@ class Action_Subscription_Update_Schedule extends \AutomateWoo\Action_Subscripti
 
 
 	/**
-	 * Set the chosen biling interval and period on a subscription.
+	 * Set the chosen billing interval and period on a subscription.
 	 *
 	 * @param array            $billing_schedule Billing schedule data. Same data as the return value of @see $this->get_object_for_edit().
 	 * @param \WC_Subscription $subscription Instance of the subscription being edited by this action.

--- a/includes/actions/update-shipping.php
+++ b/includes/actions/update-shipping.php
@@ -55,7 +55,7 @@ class Action_Subscription_Update_Shipping extends Action_Subscription_Add_Shippi
 		}
 
 		if ( $this->get_option( 'line_item_cost' ) ) {
-			$update_args['total'] = $this->get_option( 'line_item_cost' );
+			$update_args['total'] = $this->get_option( 'line_item_cost', true );
 		}
 
 		if ( ! empty( $update_args ) ) {


### PR DESCRIPTION
Will require AutomateWoo 4.6.0 to work completely, specifically: https://github.com/Prospress/automatewoo/pull/228

However these changes should be released in the add-on before AW 4.6.0 to avoid confusion.

Additionally - 1ccb951f4dcc8858a48515b0e52f106688d53449 fixes a possible issue where variables wouldn't work in the shipping line item name field 