### PR TITLE
Recalculate coupons when updating subscription product via workflow

### DIFF
--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -48,8 +48,8 @@ if ( false === AWS_Dependencies::is_subscriptions_active( '2.4' ) ) {
 	return;
 }
 
-if ( false === AWS_Dependencies::is_automatewoo_active( '4.4' ) ) {
-	AWS_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'AutomateWoo', '4.4' );
+if ( false === AWS_Dependencies::is_automatewoo_active( '4.8' ) ) {
+	AWS_Dependencies::enqueue_admin_notice( 'AutomateWoo - Subscriptions Add-on', 'AutomateWoo', '4.8' );
 	return;
 }
 

--- a/includes/actions/update-product.php
+++ b/includes/actions/update-product.php
@@ -121,7 +121,7 @@ class Action_Subscription_Update_Product extends \AutomateWoo\Action_Subscriptio
 
 		// Now we need to refresh the subscription to make sure it has the up-to-date line item then recalculate its totals so taxes etc. are updated
 		$subscription = wcs_get_subscription( $subscription->get_id() );
-		$subscription->calculate_totals();
+		$this->recalculate_subscription_totals( $subscription );
 	}
 
 


### PR DESCRIPTION
Fixes #29. 

**Note:** Recalculating coupons requires WC 3.8.
**Related PR in AW core:** https://github.com/woocommerce/automatewoo/pull/319

## Testing:

See #29 "Steps to replicate"

Sorry it's taken so long @jrick1229!