### PR TITLE
Fix "All shipping methods" bug in "Subscription → Remove Shipping" action

### DIFF
--- a/includes/abstracts/actions/edit-shipping.php
+++ b/includes/abstracts/actions/edit-shipping.php
@@ -38,7 +38,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 	 *
 	 * Optionally also add the quantity input field for the shipping if the instance requires it.
 	 */
-	function load_fields() {
+	public function load_fields() {
 		$this->add_shipping_select_field();
 
 		if ( $this->load_name_field ) {
@@ -88,7 +88,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 		$shipping_method_titles = [];
 
 		if ( $this->include_all_shipping_method ) {
-			$shipping_method_titles[$this->all_shipping_method_option_key] = __( 'All shipping methods', 'automatewoo-subscriptions' );
+			$shipping_method_titles[ $this->all_shipping_method_option_key ] = __( 'All shipping methods', 'automatewoo-subscriptions' );
 		}
 
 		foreach ( $this->get_shipping_methods() as $shipping_method_id => $shipping_method ) {

--- a/includes/abstracts/actions/edit-shipping.php
+++ b/includes/abstracts/actions/edit-shipping.php
@@ -23,6 +23,14 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 	 */
 	protected $include_all_shipping_method = false;
 
+	/**
+	 * The option key when the "All shipping methods" option is included in the
+	 * shipping method select field for this action.
+	 *
+	 * @var string
+	 */
+	protected $all_shipping_method_option_key = 'all';
+
 
 	/**
 	 * Add a shipping selection field to the action's admin UI for store owners to choose what
@@ -80,7 +88,7 @@ abstract class Abstract_Action_Subscription_Edit_Shipping extends \AutomateWoo\A
 		$shipping_method_titles = [];
 
 		if ( $this->include_all_shipping_method ) {
-			$shipping_method_titles['all'] = __( 'All shipping methods', 'automatewoo-subscriptions' );
+			$shipping_method_titles[$this->all_shipping_method_option_key] = __( 'All shipping methods', 'automatewoo-subscriptions' );
 		}
 
 		foreach ( $this->get_shipping_methods() as $shipping_method_id => $shipping_method ) {

--- a/includes/actions/remove-shipping.php
+++ b/includes/actions/remove-shipping.php
@@ -83,6 +83,6 @@ class Action_Subscription_Remove_Shipping extends Action_Subscription_Add_Shippi
 	 * @return string
 	 */
 	protected function get_note( $shipping_data ) {
-		return sprintf( __( '%1$s workflow run: removed shipping method from subscription. (Shipping Method ID: %2$d; Workflow ID: %3$d)', 'automatewoo-subscriptions' ), $this->workflow->get_title(), $shipping_data['shipping_method_id'], $this->workflow->get_id() );
+		return sprintf( __( '%1$s workflow run: removed shipping method from subscription. (Shipping Method ID: %2$s; Workflow ID: %3$d)', 'automatewoo-subscriptions' ), $this->workflow->get_title(), $shipping_data['shipping_method_id'], $this->workflow->get_id() );
 	}
 }

--- a/includes/actions/remove-shipping.php
+++ b/includes/actions/remove-shipping.php
@@ -45,7 +45,7 @@ class Action_Subscription_Remove_Shipping extends Action_Subscription_Add_Shippi
 	/**
 	 * Explain to store admin what this action does via a unique title and description.
 	 */
-	function load_admin_details() {
+	public function load_admin_details() {
 		parent::load_admin_details();
 		$this->title       = __( 'Remove Shipping', 'automatewoo-subscriptions' );
 		$this->description = __( 'Remove a shipping line item or items from a subscription, if any line items match the chosen shipping method. This is useful for bulk editing subscriptions, or to change the shipping charged to a subscriber at different stages of their subscription\'s lifecycle. Please note: all line items for the chosen shipping method will be removed.', 'automatewoo-subscriptions' );
@@ -62,7 +62,8 @@ class Action_Subscription_Remove_Shipping extends Action_Subscription_Add_Shippi
 
 		foreach ( $subscription->get_shipping_methods() as $line_item ) {
 			// Same approach used in Abstract_WC_Order::has_shipping_method() to check for method
-			if ( 0 === strpos( $line_item->get_method_id(), $shipping_data['shipping_method_id'] )
+			if (
+				0 === strpos( $line_item->get_method_id(), $shipping_data['shipping_method_id'] )
 				|| $this->all_shipping_method_option_key === $shipping_data['shipping_method_id']
 			) {
 				$subscription->remove_item( $line_item->get_id() );

--- a/includes/actions/remove-shipping.php
+++ b/includes/actions/remove-shipping.php
@@ -62,7 +62,9 @@ class Action_Subscription_Remove_Shipping extends Action_Subscription_Add_Shippi
 
 		foreach ( $subscription->get_shipping_methods() as $line_item ) {
 			// Same approach used in Abstract_WC_Order::has_shipping_method() to check for method
-			if ( 0 === strpos( $line_item->get_method_id(), $shipping_data['shipping_method_id'] ) ) {
+			if ( 0 === strpos( $line_item->get_method_id(), $shipping_data['shipping_method_id'] )
+				|| $this->all_shipping_method_option_key === $shipping_data['shipping_method_id']
+			) {
 				$subscription->remove_item( $line_item->get_id() );
 			}
 		}


### PR DESCRIPTION
Fixes #45 

Selecting "All shipping methods" in the _Subscription - Remove Shipping_ action didn't actually remove anything from the subscription. The problem was that the workflow was saving the `shipping_method_id` as `all`, and then comparing each individual shipping method in the subscription against that ID (so no single shipping method matched the ID).

I added the condition that removes each shipping method if the ID matches the one provided in the workflow, _or_ if the ID in the workflow is `all`. 

### Detailed test instructions:
- Create a subscription with one or more shipping line items.
- Create a workflow with the action Subscription → Remove Shipping and choose the "All shipping methods" option (recommend trigger Subscriptions → Subscription Note Added).
- Trigger the workflow and confirm that all the shipping methods were properly removed from the subscription.
- Confirm that the "Shipping Method ID" in the note added to the subscription by the workflow isn't `0` (should be something like `flat_rate` or `free_shipping`).