### PR TITLE
Add action: Recalculate Taxes (quick win)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The **AutomateWoo Subscriptions Add-on** adds 4 new actions:
 * **Update Shipping**: to update a shipping method's name or amount on a subscription.
 * **Remove Shipping**: to remove a chosen shipping method from a subscription.
 * **Update Currency**: to change the currency on a subscription.
+* **Recalculate Taxes**: to recalculate tax totals based on the store's current tax rates.
 
 These actions can be run on any [subscription trigger](https://automatewoo.com/docs/triggers/list/#subscriptions).
 

--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -106,10 +106,11 @@ final class AutomateWoo_Subscriptions {
 		}
 
 		$actions = array_merge( $actions, [
-			'subscription_add_shipping'    => 'AutomateWoo_Subscriptions\Action_Subscription_Add_Shipping',
-			'subscription_update_shipping' => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Shipping',
-			'subscription_remove_shipping' => 'AutomateWoo_Subscriptions\Action_Subscription_Remove_Shipping',
-			'subscription_update_currency' => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Currency',
+			'subscription_add_shipping'      => 'AutomateWoo_Subscriptions\Action_Subscription_Add_Shipping',
+			'subscription_update_shipping'   => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Shipping',
+			'subscription_remove_shipping'   => 'AutomateWoo_Subscriptions\Action_Subscription_Remove_Shipping',
+			'subscription_update_currency'   => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Currency',
+			'subscription_recalculate_taxes' => 'AutomateWoo_Subscriptions\Action_Subscription_Recalculate_Taxes',
 		] );
 
 		return $actions;

--- a/includes/actions/recalculate-taxes.php
+++ b/includes/actions/recalculate-taxes.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AutomateWoo_Subscriptions;
+
+use AutomateWoo\Action;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Action to recalculate all taxes for a subscription.
+ *
+ * @class Action_Subscription_Recalculate_Taxes
+ * @since 1.1.0
+ */
+class Action_Subscription_Recalculate_Taxes extends Action {
+
+	/**
+	 * A subscription is needed to run this action.
+	 *
+	 * @var array
+	 */
+	public $required_data_items = [ 'subscription' ];
+
+	/**
+	 * Explain to store admin what this action does via a unique title and description.
+	 */
+	public function load_admin_details() {
+		$this->title       = __( 'Recalculate Taxes', 'automatewoo-subscriptions' );
+		$this->description = __(
+			'Recalculate all taxes on a subscription based on the store\'s current tax settings. ' .
+			'This is useful for bulk editing subscriptions when new tax rates are introduced. ' .
+			'Tax rates are based on the subscription billing or shipping address (as set on WooCommerce > Settings > Tax > Calculate tax based on).',
+			'automatewoo-subscriptions'
+		);
+		$this->group = __( 'Subscription', 'automatewoo' );
+	}
+
+	/**
+	 * Run the action.
+	 */
+	public function run() {
+		$subscription = $this->workflow->data_layer()->get_subscription();
+		if ( ! $subscription ) {
+			return;
+		}
+
+		$subscription->calculate_totals( true );
+		$subscription->add_order_note(
+			sprintf(
+				__( '%1$s workflow run: recalculated taxes. (Workflow ID: %2$d)', 'automatewoo-subscriptions' ),
+				$this->workflow->get_title(),
+				$this->workflow->get_id()
+			),
+			false,
+			false
+		);
+	}
+
+}


### PR DESCRIPTION
Adds an action to a recalculate a subscriptions tax totals based on the store's current tax rates.

Fixes #12 

## Testing instructions:

- Ensure your store has at least one tax rate configured
- Create a test subscription with products with said tax rate
- Create the following workflow
![](https://d.pr/i/2DVRe9+)
- Run the workflow by adding a note to your subscription
- Assert the prices don't change
- Modify the tax rate
- Run the workflow again
- Assert the tax totals have been updated accordingly