### PR TITLE
Add action: Subscription - Regenerate Download Permissions

### DIFF
--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -106,11 +106,12 @@ final class AutomateWoo_Subscriptions {
 		}
 
 		$actions = array_merge( $actions, [
-			'subscription_add_shipping'      => 'AutomateWoo_Subscriptions\Action_Subscription_Add_Shipping',
-			'subscription_update_shipping'   => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Shipping',
-			'subscription_remove_shipping'   => 'AutomateWoo_Subscriptions\Action_Subscription_Remove_Shipping',
-			'subscription_update_currency'   => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Currency',
-			'subscription_recalculate_taxes' => 'AutomateWoo_Subscriptions\Action_Subscription_Recalculate_Taxes',
+			'subscription_add_shipping'         => 'AutomateWoo_Subscriptions\Action_Subscription_Add_Shipping',
+			'subscription_update_shipping'      => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Shipping',
+			'subscription_remove_shipping'      => 'AutomateWoo_Subscriptions\Action_Subscription_Remove_Shipping',
+			'subscription_update_currency'      => 'AutomateWoo_Subscriptions\Action_Subscription_Update_Currency',
+			'subscription_recalculate_taxes'    => 'AutomateWoo_Subscriptions\Action_Subscription_Recalculate_Taxes',
+			'subscription_regenerate_downloads' => 'AutomateWoo_Subscriptions\Action_Regenerate_Download_Permissions',
 		] );
 
 		return $actions;

--- a/includes/actions/regenerate-download-permissions.php
+++ b/includes/actions/regenerate-download-permissions.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AutomateWoo_Subscriptions;
+
+use AutomateWoo\Action;
+use Exception;
+use WC_Data_Store;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Action to regenerate download permissions for a subscription.
+ *
+ * @class Action_Regenerate_Download_Permissions
+ * @since 1.2.0
+ */
+class Action_Regenerate_Download_Permissions extends Action {
+
+	/**
+	 * A subscription is needed to run this action.
+	 *
+	 * @var array
+	 */
+	public $required_data_items = [ 'subscription' ];
+
+	/**
+	 * Explain to store admin what this action does via a unique title and description.
+	 */
+	public function load_admin_details() {
+		$this->title = __( 'Regenerate Download Permissions', 'automatewoo-subscriptions' );
+		$this->group = __( 'Subscription', 'automatewoo' );
+	}
+
+	/**
+	 * Run the action.
+	 *
+	 * @throws Exception If there's an error running the action.
+	 */
+	public function run() {
+		$subscription = $this->workflow->data_layer()->get_subscription();
+		if ( ! $subscription ) {
+			return;
+		}
+
+		// Method used in \WC_Meta_Box_Order_Actions::save
+		$data_store = WC_Data_Store::load( 'customer-download' );
+		$data_store->delete_by_order_id( $subscription->get_id() );
+		wc_downloadable_product_permissions( $subscription->get_id(), true );
+	}
+
+}


### PR DESCRIPTION
Fixes #40 

## Testing:
- Create a downloadable product with at least 1 download 
- Create a test subscription that doesn't contain the downloadable product
- Edit the test subscription and manually add the downloadable product
- View the subscription in the my-account area and assert that you can't download anything yet
- Create a manual workflow for subscriptions
- Add the action "Subscription - Regenerate Download Permissions"
- Run the workflow for all your subscriptions
- View the subscription in the my-account area and assert that you can download the file