### PR TITLE
Rename ‘master’ production branch to ‘trunk’

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In the future, we may add actions to:
 
 To install:
 
-1. Download the latest version of the plugin [here](https://github.com/woocommerce/automatewoo-subscriptions/archive/master.zip)
+1. Download the latest version of the plugin [here](https://github.com/woocommerce/automatewoo-subscriptions/releases)
 1. Go to **Plugins > Add New > Upload** administration screen on your WordPress site
 1. Select the ZIP file you just downloaded
 1. Click **Install Now**

--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -14,7 +14,7 @@
  * WC tested up to: 4.2
  *
  * GitHub Plugin URI: woocommerce/automatewoo-subscriptions
- * GitHub Branch: master
+ * Primary Branch: trunk
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Part of https://github.com/woocommerce/automatewoo/issues/746

I've added a ["Primary Branch" header for the GitHub updater](https://github.com/afragen/github-updater/wiki/Settings#primary-branch). We will need to ensure 1.2.1 is pushed to `master` since existing sites will be looking there for an update.