### PR TITLE
WordPress 5.6 & PHP 8 Compatibility

### DIFF
--- a/automatewoo-subscriptions.php
+++ b/automatewoo-subscriptions.php
@@ -8,10 +8,10 @@
  * License: GPLv3
  * Version: 1.2.1
  * Requires at least: 4.0
- * Tested up to: 5.4
+ * Tested up to: 5.6
  *
  * WC requires at least: 3.0
- * WC tested up to: 4.2
+ * WC tested up to: 4.7
  *
  * GitHub Plugin URI: woocommerce/automatewoo-subscriptions
  * Primary Branch: trunk


### PR DESCRIPTION
This PR just increases the tested up to / compatible with tags for WordPress 5.6 and WooCommerce 4.7

There doesn't seem to be any issues with PHP 8 and WP 5.6:

- I ran PHPCS with PHPCompatibility sniff and found no issues.
- There were no unit tests to check.
- I tested some basic functionality using PHP8 and WP 5.6 and did not notice any errors or warnings in both PHP and JS console.

Closes #55