### PR TITLE
Add package.json with minimalistic build task,

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == AutomateWoo - Subscriptions Add-on changelog ==
 
+2020-xx-xx - version 1.2.2
+* Fix - Issue with undefined $shipping_data variable
+
 2020-10-16 - version 1.2.1
 * Tweak - Renames production branch from 'master' to 'trunk'
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+
+    "name": "automatewoo-subscriptions",
+    "title": "AutomateWoo - Subscriptions Add-on",
+    "description": "Advanced actions for automating a subscription's lifecycle with AutomateWoo.",
+    "license": "GPL-3.0-only",
+	"version": "1.2.1",
+	"scripts": {
+		"build": "git archive --format zip HEAD | cat > $npm_package_name.zip"
+	}
+}


### PR DESCRIPTION
I made it after I forgot we do not deploy this plugin anywhere ;)
to be able to use with woorelease.
https://github.com/woocommerce/woorelease#requirements-for-your-product

@jconroy @nima-karimi Do you think there is a value in having package.json anyway?
The downside is that it could make `woorelease` run even though it's not desired.